### PR TITLE
ARM: dts: bcm2711-rpi-4-b: I2C aliases and pulls

### DIFF
--- a/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
+++ b/arch/arm/boot/dts/bcm2711-rpi-4-b.dts
@@ -23,6 +23,10 @@
 		mmc0 = &emmc2;
 		mmc1 = &mmcnr;
 		mmc2 = &sdhost;
+		i2c3 = &i2c3;
+		i2c4 = &i2c4;
+		i2c5 = &i2c5;
+		i2c6 = &i2c6;
 		/delete-property/ ethernet;
 		/delete-property/ intc;
 		ethernet0 = &genet;
@@ -207,31 +211,37 @@
 	i2c0_pins: i2c0 {
 		brcm,pins = <0 1>;
 		brcm,function = <BCM2835_FSEL_ALT0>;
+		brcm,pull = <BCM2835_PUD_UP>;
 	};
 
 	i2c1_pins: i2c1 {
 		brcm,pins = <2 3>;
 		brcm,function = <BCM2835_FSEL_ALT0>;
+		brcm,pull = <BCM2835_PUD_UP>;
 	};
 
 	i2c3_pins: i2c3 {
 		brcm,pins = <4 5>;
 		brcm,function = <BCM2835_FSEL_ALT5>;
+		brcm,pull = <BCM2835_PUD_UP>;
 	};
 
 	i2c4_pins: i2c4 {
 		brcm,pins = <8 9>;
 		brcm,function = <BCM2835_FSEL_ALT5>;
+		brcm,pull = <BCM2835_PUD_UP>;
 	};
 
 	i2c5_pins: i2c5 {
 		brcm,pins = <12 13>;
 		brcm,function = <BCM2835_FSEL_ALT5>;
+		brcm,pull = <BCM2835_PUD_UP>;
 	};
 
 	i2c6_pins: i2c6 {
 		brcm,pins = <22 23>;
 		brcm,function = <BCM2835_FSEL_ALT5>;
+		brcm,pull = <BCM2835_PUD_UP>;
 	};
 
 	i2s_pins: i2s {


### PR DESCRIPTION
The I2C interface nodes need aliases to give them fixed bus numbers,
and setting the pulls on the GPIOs (particularly 9-13) increases the
chances of the bus working with weak or absent external pulls.

See: https://www.raspberrypi.org/forums/posting.php?mode=reply&f=107&t=248439

Signed-off-by: Phil Elwell <phil@raspberrypi.org>